### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/laravel.yml
+++ b/.github/workflows/laravel.yml
@@ -1,4 +1,6 @@
 name: Laravel
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/UsherM8/yourairtravel/security/code-scanning/1](https://github.com/UsherM8/yourairtravel/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow (either at the root level or per job) that grants only the minimal scopes needed. For this Laravel test workflow, the steps only read the repository code and use external tools; they do not need to write to the repository or other GitHub resources. Therefore, `contents: read` at the workflow or job level is sufficient.

The single best fix without changing functionality is to add a root-level `permissions` block right after the `name: Laravel` line. This will apply to all jobs in the workflow (currently just `laravel-tests`) and constrain `GITHUB_TOKEN` to read-only access to repository contents. No additional imports or methods are needed since this is a YAML configuration change only.

Concretely, in `.github/workflows/laravel.yml`, insert:

```yaml
permissions:
  contents: read
```

after the existing `name: Laravel` line (line 1 in the snippet). The rest of the workflow remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
